### PR TITLE
fix: wrong caret place

### DIFF
--- a/packages/components/snippeter/src/styles/whiteboard.scss
+++ b/packages/components/snippeter/src/styles/whiteboard.scss
@@ -14,6 +14,7 @@
         border: 1px solid transparent;
         display: inline-block;
         min-width: 1px;
+        min-height: inherit;
       }
 
       & [snippet] {


### PR DESCRIPTION
`snippeter-phrase` inherits min-height